### PR TITLE
Add ability to set custom directory path for unmanaged stacks

### DIFF
--- a/backend/migrations/20231203_01_stack_paths.ts
+++ b/backend/migrations/20231203_01_stack_paths.ts
@@ -1,0 +1,13 @@
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.schema.createTable("stack_paths", (table) => {
+        table.string("stack_name").primary();
+        table.string("directory_path").notNullable();
+        table.timestamps(true, true);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.schema.dropTable("stack_paths");
+}

--- a/backend/models/stack-path.ts
+++ b/backend/models/stack-path.ts
@@ -1,0 +1,14 @@
+import { Model } from "objection";
+
+export class StackPath extends Model {
+    static tableName = "stack_paths";
+
+    stack_name!: string;
+    directory_path!: string;
+    created_at!: string;
+    updated_at!: string;
+
+    static get idColumn() {
+        return "stack_name";
+    }
+}

--- a/backend/routers/main-router.ts
+++ b/backend/routers/main-router.ts
@@ -1,6 +1,7 @@
 import { DockgeServer } from "../dockge-server";
 import { Router } from "../router";
 import express, { Express, Router as ExpressRouter } from "express";
+import { stackPathRouter } from "./stack-path-router";
 
 export class MainRouter extends Router {
     create(app: Express, server: DockgeServer): ExpressRouter {
@@ -9,6 +10,8 @@ export class MainRouter extends Router {
         router.get("/", (req, res) => {
             res.send(server.indexHTML);
         });
+
+        router.use("/api/stacks", stackPathRouter);
 
         // Robots.txt
         router.get("/robots.txt", async (_request, response) => {

--- a/backend/routers/stack-path-router.ts
+++ b/backend/routers/stack-path-router.ts
@@ -1,0 +1,35 @@
+import express from "express";
+import { Stack } from "../stack";
+import { DockgeServer } from "../dockge-server";
+
+export const stackPathRouter = express.Router();
+
+stackPathRouter.post("/:stackName/path", async (req, res) => {
+    try {
+        const stackName = req.params.stackName;
+        const directoryPath = req.body.directoryPath;
+
+        if (!directoryPath) {
+            return res.status(400).json({
+                message: "directoryPath is required"
+            });
+        }
+
+        const stack = await Stack.getStack(req.app.get("server") as DockgeServer, stackName);
+        await stack.setCustomPath(directoryPath);
+
+        res.json({
+            message: "Stack path updated successfully"
+        });
+    } catch (e) {
+        if (e instanceof Error) {
+            res.status(400).json({
+                message: e.message
+            });
+        } else {
+            res.status(500).json({
+                message: "Internal server error"
+            });
+        }
+    }
+});

--- a/frontend/src/components/SetPathDialog.vue
+++ b/frontend/src/components/SetPathDialog.vue
@@ -1,0 +1,85 @@
+<template>
+    <div class="modal" :class="{ 'is-active': show }">
+        <div class="modal-background" @click="close"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title">Set Stack Directory</p>
+                <button class="delete" aria-label="close" @click="close"></button>
+            </header>
+            <section class="modal-card-body">
+                <div class="field">
+                    <label class="label">Directory Path</label>
+                    <div class="control">
+                        <input class="input" type="text" v-model="directoryPath" placeholder="/path/to/stack/directory">
+                    </div>
+                    <p class="help">Enter the absolute path to the directory containing your compose file</p>
+                </div>
+            </section>
+            <footer class="modal-card-foot">
+                <button class="button is-success" @click="save" :class="{ 'is-loading': loading }">Save</button>
+                <button class="button" @click="close">Cancel</button>
+            </footer>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { useToast } from "vue-toastification";
+
+const props = defineProps<{
+    show: boolean;
+    stackName: string;
+}>();
+
+const emit = defineEmits<{
+    (e: "close"): void;
+    (e: "saved"): void;
+}>();
+
+const toast = useToast();
+const directoryPath = ref("");
+const loading = ref(false);
+
+const close = () => {
+    directoryPath.value = "";
+    emit("close");
+};
+
+const save = async () => {
+    if (!directoryPath.value) {
+        toast.error("Please enter a directory path");
+        return;
+    }
+
+    loading.value = true;
+    try {
+        const response = await fetch(`/api/stacks/${props.stackName}/path`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                directoryPath: directoryPath.value,
+            }),
+        });
+
+        if (!response.ok) {
+            const data = await response.json();
+            throw new Error(data.message || "Failed to set path");
+        }
+
+        toast.success("Stack path updated successfully");
+        emit("saved");
+        close();
+    } catch (error) {
+        if (error instanceof Error) {
+            toast.error(error.message);
+        } else {
+            toast.error("Failed to set path");
+        }
+    } finally {
+        loading.value = false;
+    }
+};
+</script>

--- a/frontend/src/components/StackListItem.vue
+++ b/frontend/src/components/StackListItem.vue
@@ -1,19 +1,32 @@
 <template>
-    <router-link :to="url" :class="{ 'dim' : !stack.isManagedByDockge }" class="item">
-        <Uptime :stack="stack" :fixed-width="true" class="me-2" />
-        <div class="title">
-            <span>{{ stackName }}</span>
-            <div v-if="$root.agentCount > 1" class="endpoint">{{ endpointDisplay }}</div>
-        </div>
-    </router-link>
+    <div class="item-wrapper">
+        <router-link :to="url" :class="{ 'dim' : !stack.isManagedByDockge }" class="item">
+            <Uptime :stack="stack" :fixed-width="true" class="me-2" />
+            <div class="title">
+                <span>{{ stackName }}</span>
+                <div v-if="$root.agentCount > 1" class="endpoint">{{ endpointDisplay }}</div>
+            </div>
+        </router-link>
+        <button v-if="!stack.isManagedByDockge" class="button is-small is-info" @click="showSetPathDialog = true">
+            Set Path
+        </button>
+    </div>
+    <SetPathDialog
+        :show="showSetPathDialog"
+        :stack-name="stackName"
+        @close="showSetPathDialog = false"
+        @saved="onPathSaved"
+    />
 </template>
 
 <script>
 import Uptime from "./Uptime.vue";
+import SetPathDialog from "./SetPathDialog.vue";
 
 export default {
     components: {
-        Uptime
+        Uptime,
+        SetPathDialog
     },
     props: {
         /** Stack this represents */
@@ -50,6 +63,7 @@ export default {
     data() {
         return {
             isCollapsed: true,
+            showSetPathDialog: false,
         };
     },
     computed: {
@@ -82,6 +96,14 @@ export default {
 
     },
     methods: {
+        /**
+         * Callback when the path is saved successfully
+         */
+        onPathSaved() {
+            // Refresh the page to update the stack status
+            window.location.reload();
+        },
+
         /**
          * Changes the collapsed value of the current stack and saves
          * it to local storage
@@ -129,6 +151,13 @@ export default {
     padding-right: 2px !important;
 }
 
+.item-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-right: 8px;
+}
+
 .item {
     text-decoration: none;
     display: flex;
@@ -136,7 +165,7 @@ export default {
     min-height: 52px;
     border-radius: 10px;
     transition: all ease-in-out 0.15s;
-    width: 100%;
+    flex-grow: 1;
     padding: 5px 8px;
     &.disabled {
         opacity: 0.3;


### PR DESCRIPTION
This PR implements the feature request from #679 to allow setting custom directory paths for unmanaged stacks.

### Changes

- Added a new `StackPath` model and migration for storing custom paths
- Added a "Set Path" button next to unmanaged stacks
- Added a dialog for setting the custom directory path
- Updated the Stack class to handle custom paths
- Added an API endpoint for setting stack paths

### How it works

1. When a stack is not managed by Dockge, a "Set Path" button appears next to it
2. Clicking the button opens a dialog where you can enter the absolute path to the directory containing your compose file
3. After setting the path, the stack becomes manageable by Dockge
4. The custom path is stored in the database and used for all stack operations

Closes #679